### PR TITLE
Fix command parsing bugs and modernize Maven compiler configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,31 +13,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
                 <configuration>
-                    <encoding>utf-8</encoding>
-                    <source>7</source>
-                    <target>7</target>
+                    <encoding>UTF-8</encoding>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>ideauidesigner-maven-plugin</artifactId>
-                <version>1.0-beta-1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>javac2</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-                <configuration>
-                    <fork>true</fork>
-                    <debug>true</debug>
-                    <failOnError>true</failOnError>
-                </configuration>
-            </plugin>
-
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/src/main/java/club/lanhaoo/chat/Classes/Message.java
+++ b/src/main/java/club/lanhaoo/chat/Classes/Message.java
@@ -8,10 +8,6 @@
 package club.lanhaoo.chat.Classes;
 
 import com.google.gson.Gson;
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
-import org.apache.commons.io.FileUtils;
-
-import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.*;
@@ -138,15 +134,13 @@ public class Message {
     public String getMD5(){
         Gson gson=new Gson();
         byte[] bytesOfMessage =gson.toJson(this).getBytes(StandardCharsets.UTF_8);
-        MessageDigest md5 = null;
         try {
-            md5 = MessageDigest.getInstance("MD5");
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            byte[] thedigest = md5.digest(bytesOfMessage);
+            BigInteger bigInt = new BigInteger(1,thedigest);
+            return bigInt.toString(16);
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+            throw new IllegalStateException("MD5 algorithm is not available", e);
         }
-        byte[] thedigest = md5.digest(bytesOfMessage);
-        BigInteger bigInt = new BigInteger(1,thedigest);
-        String hashtext = bigInt.toString(16);
-        return hashtext;
     }
 }

--- a/src/main/java/club/lanhaoo/chat/Server.java
+++ b/src/main/java/club/lanhaoo/chat/Server.java
@@ -3,14 +3,12 @@ package club.lanhaoo.chat;
 import club.lanhaoo.chat.Classes.Message;
 import com.google.gson.Gson;
 
-import java.math.BigInteger;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.List;
 
 /**
  * @Author: LanHao
@@ -44,8 +42,8 @@ public class Server {
         System.out.println("在 " + localHost + " : 2112" + "上运行服务端 ");
         boolean ServerOn = true;
 
-        ArrayList Iplist = new ArrayList();
-        ArrayList BanIp = new ArrayList();
+        List<String> ipList = new ArrayList<String>();
+        List<String> banIp = new ArrayList<String>();
 
         String serverPassword="mima111";
 
@@ -61,17 +59,23 @@ public class Server {
             Gson gson = new Gson();
             Message message = gson.fromJson(pure_message, Message.class);
 
-            String message_content=message.getContent();
+            String message_content = message.getContent();
             String command = message.getCommand();
+            if (message_content == null) {
+                message_content = "";
+            }
+            if (command == null) {
+                command = "";
+            }
 
-            Iplist.add(fromIP);
+            ipList.add(fromIP);
             //todo 超级命令登陆ip
 
             new Message("confirm","", message.getMD5()).send(fromIP);
 
 
 
-            if (BanIp.contains(fromIP)) {
+            if (banIp.contains(fromIP)) {
                 //如果来自被封禁IP，则不进行操作
                 String bannedtips = "你已被管理员封禁，无法发送群消息&[系统消息]";
                 long mtime = new Date().getTime();
@@ -98,18 +102,24 @@ public class Server {
                 if (command.contains("SYSTEM_COMMAND")) {
                     if (message_content.contains(serverPassword)){
                         String mcontent=null;
+                        String[] commandParts = message_content.split("#");
+                        String targetIp = commandParts.length > 2 ? commandParts[2] : null;
 
                         if (command.contains(banipCommand)){
-                            BanIp.add(message_content.split("#")[2]);
-                            System.out.println("Banned ip:" + message_content.split("#")[2]);
-                            mcontent="已封禁IP: "+fromIP;
+                            if (targetIp != null) {
+                                banIp.add(targetIp);
+                                System.out.println("Banned ip:" + targetIp);
+                                mcontent="已封禁IP: "+targetIp;
+                            }
 
                         }
 
                         if (command.contains(unbanipCommand)){
-                            BanIp.remove(message_content.split("#")[2]);
-                            System.out.println("Unbanned ip:" + message_content.split("#")[2]);
-                            mcontent="解封IP: "+fromIP;
+                            if (targetIp != null) {
+                                banIp.remove(targetIp);
+                                System.out.println("Unbanned ip:" + targetIp);
+                                mcontent="解封IP: "+targetIp;
+                            }
 
                         }
 

--- a/src/main/java/club/lanhaoo/chat/client.java
+++ b/src/main/java/club/lanhaoo/chat/client.java
@@ -4,7 +4,6 @@ import club.lanhaoo.chat.Classes.Message;
 import club.lanhaoo.chat.Classes.UserSettings;
 import club.lanhaoo.chat.HttpFileShare.App;
 
-import java.util.Date;
 import java.util.Scanner;
 
 
@@ -42,8 +41,7 @@ public class client {
 
         while (inCommunication){
 
-            Scanner scanner=new Scanner(System.in);
-            String raw_Data=scanner.nextLine();
+            String raw_Data=sc.nextLine();
 
 //            含有系统命令
             if (raw_Data.startsWith("SYSTEM_COMMAND.")){
@@ -61,8 +59,10 @@ public class client {
                 if (raw_Data.contains("WHOIS")){
                     command_sys="WHOIS";
                 }
-
-                long mtime = new Date().getTime();
+                if (command_sys == null) {
+                    System.out.println("未知系统命令");
+                    continue;
+                }
 
                 Message message = new Message("text", "SYSTEM_COMMAND."+command_sys, raw_Data);
                 if (!message.send(userSettings)) {
@@ -76,14 +76,17 @@ public class client {
             if (raw_Data.startsWith("UserCommand.")){
 
                 if (raw_Data.contains(secret_Talk)){
-                    String toip=raw_Data.split("#")[1];
-                    String string=raw_Data.split("#")[2];
+                    String[] commandParts = raw_Data.split("#", 3);
+                    if (commandParts.length < 3) {
+                        System.out.println("secretTalk 格式错误，应为 UserCommand.secretTalk#ip#content");
+                    } else {
+                        String toip = commandParts[1];
+                        String string = commandParts[2];
+                        Message message = new Message("text", "", string);
 
-                    long mtime = new Date().getTime();
-                    Message message = new Message("text", "", string);
-
-                    if (!message.send(toip)) {
-                        System.out.println("发送失败\n");
+                        if (!message.send(toip)) {
+                            System.out.println("发送失败\n");
+                        }
                     }
                 }
 
@@ -112,7 +115,7 @@ public class client {
                 if (raw_Data.contains("fileShare")){
                     if (!userSettings.isOnFileSharing()){
                         System.out.println("请设置文件分享密码");
-                        app_fileShare.setWebpassword(scanner.nextLine());
+                        app_fileShare.setWebpassword(sc.nextLine());
                         System.out.println("开始文件分享,端口8089,密码 "+app_fileShare.getWebpassword());
                         app_fileShare.start();
                         userSettings.setOnFileSharing(true);
@@ -126,7 +129,6 @@ public class client {
                 continue;
             }
 
-            long mtime = new Date().getTime();
             Message message = new Message("text", "", raw_Data);
             message.setFromIp(Server.getIpAddress());
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and crashes caused by null `command`/`content` and unsafe array indexing in admin/user command handling. 
- Reduce type-safety issues from raw collections and make message hash generation robust. 
- Update build settings to a modern, predictable configuration that targets Java 8 and uses explicit compiler plugin settings.

### Description
- Updated `pom.xml` to remove the obsolete `ideauidesigner-maven-plugin` and modernize the compiler plugin by setting `version` to `3.14.0`, `encoding` to `UTF-8`, and `source`/`target` to `8`.
- Hardened `Server` (`src/main/java/club/lanhaoo/chat/Server.java`) by replacing raw `ArrayList` usage with `List<String>`, adding null-safe checks for `message.getContent()` and `message.getCommand()`, validating `split("#")` results before indexing, and making ban/unban messages reference the actual target IP.
- Improved `client` (`src/main/java/club/lanhaoo/chat/client.java`) input handling by reusing a single `Scanner`, validating `SYSTEM_COMMAND` parsing to avoid `null` commands, using a limited `split` for `secretTalk` with format validation, and reusing the scanner for file-share password input.
- Cleaned and simplified `Message` (`src/main/java/club/lanhaoo/chat/Classes/Message.java`) by removing unused imports and making `getMD5()` compute the digest directly and throw an explicit `IllegalStateException` if the MD5 algorithm is unavailable.

### Testing
- Ran `mvn -q test`, which failed due to Maven plugin resolution returning HTTP 403 (remote repository access issue), not due to compile errors. 
- Ran `mvn -q -DskipTests compile`, which failed for the same Maven Central plugin resolution `403` error. 
- Ran `mvn -q -DskipTests compile -o` (offline), which failed because required plugins were not cached locally; no automated unit tests executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfccbb4f108326a994c7bc2c5bba5a)